### PR TITLE
Fix temperature appearing as the value for gyro_x

### DIFF
--- a/data/sql/imu_sql.go
+++ b/data/sql/imu_sql.go
@@ -39,14 +39,14 @@ func ImuPurgeQuery() string {
 type ImuSqlWrapper struct {
 	acceleration *imu.Acceleration
 	temperature  iim42652.Temperature
-	gyroscope *iim42652.AngularRate
+	gyroscope    *iim42652.AngularRate
 }
 
 func NewImuSqlWrapper(temperature iim42652.Temperature, acceleration *imu.Acceleration, gyroscope *iim42652.AngularRate) *ImuSqlWrapper {
 	return &ImuSqlWrapper{
 		acceleration: acceleration,
 		temperature:  temperature,
-		gyroscope:     gyroscope,
+		gyroscope:    gyroscope,
 	}
 }
 
@@ -56,9 +56,9 @@ func (w *ImuSqlWrapper) InsertQuery() (string, string, []any) {
 		w.acceleration.X,
 		w.acceleration.Y,
 		w.acceleration.Z,
-		*w.temperature,
 		w.gyroscope.X,
 		w.gyroscope.Y,
 		w.gyroscope.Z,
+		*w.temperature,
 	}
 }


### PR DESCRIPTION
Ticket: Hivemapper/hdcs_firmware#44

Readings were being written to the database in the wrong order.