### PR TITLE
Check for and apply magnetometerCalibration config.

### DIFF
--- a/cmd/datalogger/datahandler.go
+++ b/cmd/datalogger/datahandler.go
@@ -110,7 +110,21 @@ func (h *DataHandler) HandlerGnssData(data *neom9n.Data) error {
 }
 
 func (h *DataHandler) HandlerMagnetometerData(system_time time.Time, mag_x float64, mag_y float64, mag_z float64) error {
-	err := h.sqliteLogger.Log(magnetometer.NewMagnetometerSqlWrapper(system_time, mag_x, mag_y, mag_z))
+	var calib_x float64
+	var calib_y float64
+	var calib_z float64
+	calibrationString := h.sqliteLogger.GetConfig("magnetometerCalibration")
+	// fmt.Println(calibrationString)
+	_, err := fmt.Sscanf(calibrationString, "%f %f %f", &calib_x, &calib_y, &calib_z)
+	if err != nil {
+		fmt.Printf("Failed to parse magnetometer config %v\n", err)
+		calib_x = 0.0
+		calib_y = 0.0
+		calib_z = 0.0
+	}
+	// fmt.Printf("%v %v %v\n", calib_x, calib_y, calib_z)
+
+	err = h.sqliteLogger.Log(magnetometer.NewMagnetometerSqlWrapper(system_time, mag_x-calib_x, mag_y-calib_y, mag_z-calib_z))
 	if err != nil {
 		return fmt.Errorf("logging magnetometer data to sqlite: %w", err)
 	}

--- a/cmd/datalogger/datahandler.go
+++ b/cmd/datalogger/datahandler.go
@@ -128,14 +128,12 @@ func (h *DataHandler) HandlerMagnetometerData(system_time time.Time, mag_x float
 	var center [3]float64
 	var transform [3][3]float64
 	calibrationString := h.sqliteLogger.GetConfig("magnetometerCalibration")
-	fmt.Printf("calibration string: %v\n", calibrationString)
 	_, err := fmt.Sscanf(calibrationString, "%f %f %f %f %f %f %f %f %f %f %f %f",
 		&transform[0][0], &transform[0][1], &transform[0][2],
 		&transform[1][0], &transform[1][1], &transform[1][2],
 		&transform[2][0], &transform[2][1], &transform[2][2],
 		&center[0], &center[1], &center[2])
 	if err != nil {
-		fmt.Printf("Failed to parse magnetometer config %v\n", err)
 		center = [3]float64{0, 0, 0}
 		transform = [3][3]float64{
 			{1, 0, 0},
@@ -143,11 +141,8 @@ func (h *DataHandler) HandlerMagnetometerData(system_time time.Time, mag_x float
 			{0, 0, 1},
 		}
 	}
-	fmt.Printf("%v %v\n", transform, center)
 
 	calibrated_mag := calibrate(mag_x, mag_y, mag_z, transform, center)
-	fmt.Printf("uncalibrated: %v %v %v", mag_x, mag_y, mag_z)
-	fmt.Printf("calibrated: %v", calibrated_mag)
 	err = h.sqliteLogger.Log(magnetometer.NewMagnetometerSqlWrapper(system_time, calibrated_mag[0], calibrated_mag[1], calibrated_mag[2]))
 	if err != nil {
 		return fmt.Errorf("logging magnetometer data to sqlite: %w", err)

--- a/logger/sqlite.go
+++ b/logger/sqlite.go
@@ -32,7 +32,6 @@ func (s *Sqlite) GetConfig(key string) string {
 	var result string
 	err := row.Scan(&result)
 	if err != nil {
-		fmt.Printf("Failed to get config %v: %v\n", key, err)
 		result = ""
 	}
 	return result

--- a/logger/sqlite.go
+++ b/logger/sqlite.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"sync"
 	"time"
+
 	"github.com/Hivemapper/gnss-controller/device/neom9n"
 	"github.com/Hivemapper/hivemapper-data-logger/data/imu"
 	"github.com/streamingfast/imu-controller/device/iim42652"
@@ -24,6 +25,17 @@ type Sqlite struct {
 	createTableQueryFuncList []CreateTableQueryFunc
 
 	logs chan Sqlable
+}
+
+func (s *Sqlite) GetConfig(key string) string {
+	row := s.DB.QueryRow("SELECT value FROM config WHERE key = ?", key)
+	var result string
+	err := row.Scan(&result)
+	if err != nil {
+		fmt.Printf("Failed to get config %v: %v\n", key, err)
+		result = ""
+	}
+	return result
 }
 
 func NewSqlite(file string, createTableQueryFuncList []CreateTableQueryFunc, purgeQueryFuncList []PurgeQueryFunc) *Sqlite {
@@ -140,15 +152,15 @@ func (s *Sqlite) Init(logTTL time.Duration) error {
 						delete(queries, query)
 						break // Success, exit the retry loop
 					}
-		
-					if attempt < maxRetries - 1 {
-						delay := time.Duration(100 * (1 << attempt)) * time.Millisecond
+
+					if attempt < maxRetries-1 {
+						delay := time.Duration(100*(1<<attempt)) * time.Millisecond
 						time.Sleep(delay)
 						fmt.Println(err)
 						s.InsertErrorLog(fmt.Sprintf("Retry attempt %d for query: %s", attempt+1, err))
 					}
 				}
-		
+
 				if err != nil {
 					s.InsertErrorLog(err.Error()) // Log final failure
 					fmt.Println(err)


### PR DESCRIPTION
Ticket: https://github.com/Hivemapper/hdcs_firmware/issues/70

`magnetometerCalibration` is stored in the `config` table of the sqlite database and is formatted as a string of 12 space-separated floats e.g. "1.0 2.2 3.4 4.44 5 6 7 8 9 10 11 12"

The first 9 entries are the coefficients of the transformation matrix
```
TR = [0 1 2]
     [3 4 5]
     [6 7 8]
```

The next 3 are x,y, and z center offsets

```
center = [0, 1, 2]
```