### PR TITLE
Gnss auth time fix

### DIFF
--- a/data/sql/gnss_auth_sql.go
+++ b/data/sql/gnss_auth_sql.go
@@ -53,6 +53,6 @@ func (w *GnssAuthSqlWrapper) InsertQuery() (string, string, []any) {
 		b64.StdEncoding.EncodeToString(w.gnssData.SecEcsign.FinalHash[:]),
 		b64.StdEncoding.EncodeToString(w.gnssData.SecEcsign.SessionId[:]),
 		b64.StdEncoding.EncodeToString(w.gnssData.SecEcsign.EcdsaSignature[:]),
-		time.Now(),
+		time.Now().Format("2006-01-02 15:04:05.99999"),
 	}
 }

--- a/data/sql/gnss_auth_sql.go
+++ b/data/sql/gnss_auth_sql.go
@@ -2,6 +2,7 @@ package sql
 
 import (
 	b64 "encoding/base64"
+	"time"
 
 	"github.com/Hivemapper/gnss-controller/device/neom9n"
 )
@@ -52,6 +53,6 @@ func (w *GnssAuthSqlWrapper) InsertQuery() (string, string, []any) {
 		b64.StdEncoding.EncodeToString(w.gnssData.SecEcsign.FinalHash[:]),
 		b64.StdEncoding.EncodeToString(w.gnssData.SecEcsign.SessionId[:]),
 		b64.StdEncoding.EncodeToString(w.gnssData.SecEcsign.EcdsaSignature[:]),
-		w.gnssData.SystemTime.Format("2006-01-02 15:04:05.99999"),
+		time.Now(),
 	}
 }


### PR DESCRIPTION
Use `time.Now()` for gnssAuth time.  GnssAuth should not be checking the gnssData struct for the time