### PR TITLE
Add github workflow to create a new release when a new tag is pushed.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,3 +23,13 @@ jobs:
     - name: Build
       run: go build -v ./...
 
+    - name: Run GoReleaser
+      uses: goreleaser/goreleaser-action@v5
+      with:
+        # either 'goreleaser' (default) or 'goreleaser-pro'
+        distribution: goreleaser
+        # 'latest', 'nightly', or a semver
+        version: latest
+        args: release --clean
+      # env:
+      #   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,5 +31,5 @@ jobs:
         # 'latest', 'nightly', or a semver
         version: latest
         args: release --clean
-      # env:
-      #   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,7 +4,6 @@
 name: Go
 
 on:
-  pull_request:
   push:
     # run only against tags
     tags:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,9 +4,11 @@
 name: Go
 
 on:
+  pull_request:
   push:
-    branches: [ "main" ]
-  workflow_dispatch:
+    # run only against tags
+    tags:
+      - "*"
 
 jobs:
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,9 +22,6 @@ jobs:
       with:
         go-version: '1.21'
 
-    - name: Build
-      run: go build -v ./...
-
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v5
       with:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,25 @@
+# This workflow will build a golang project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
+
+name: Go
+
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.21'
+
+    - name: Build
+      run: go build -v ./...
+


### PR DESCRIPTION
Ticket: https://github.com/Hivemapper/hdcs_firmware/issues/73

Usage: Create a new tag on the commit you want to create a release of.

`git tag -a "a.b.c" -m "my release"`

`git push --tags`

The tag needed to be pushed to main when I tried this, not sure if that's a requirement