### PR TITLE
Make changes to allow building the production datalogger from source.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ replace github.com/daedaleanai/ublox => github.com/Hivemapper/sf-ublox v0.0.0-20
 //replace github.com/streamingfast/imu-controller => ../imu-controller
 
 require (
-	github.com/Hivemapper/gnss-controller v1.0.3-0.20240514192901-01235228b063
+	github.com/Hivemapper/gnss-controller v1.0.3-0.20240819070221-78cf51b8a5c6
 	github.com/bufbuild/connect-go v1.10.0
 	github.com/fsnotify/fsnotify v1.6.0
 	github.com/google/uuid v1.3.1

--- a/go.mod
+++ b/go.mod
@@ -6,12 +6,12 @@ go 1.20
 // replace github.com/daedaleanai/ublox => github.com/streamingfast/ublox v0.0.0-20230815154721-b29363712a91
 replace github.com/daedaleanai/ublox => github.com/Hivemapper/sf-ublox v0.0.0-20240221201612-d92d22b86230
 
-replace github.com/Hivemapper/gnss-controller => ../gnss-controller
+//replace github.com/Hivemapper/gnss-controller => ../gnss-controller
 
 //replace github.com/streamingfast/imu-controller => ../imu-controller
 
 require (
-	github.com/Hivemapper/gnss-controller v1.0.3-0.20240402232423-1de9f3a3a7f8
+	github.com/Hivemapper/gnss-controller v1.0.3-0.20240514192901-01235228b063
 	github.com/bufbuild/connect-go v1.10.0
 	github.com/fsnotify/fsnotify v1.6.0
 	github.com/google/uuid v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/Hivemapper/gnss-controller v1.0.3-0.20240514192901-01235228b063 h1:C56Dlm9qQ+SczRVg/hho/uqTK1nYaXyzQNkWPz/Ulbo=
 github.com/Hivemapper/gnss-controller v1.0.3-0.20240514192901-01235228b063/go.mod h1:womfs6qB93Ki7FczKxw0pR6H0MGNBM6j8bhCjVX4pWE=
+github.com/Hivemapper/gnss-controller v1.0.3-0.20240819070221-78cf51b8a5c6 h1:LiAOnOioI6nLW5sWv+swlDZ4rutkGzQi18pr8vu9pCU=
+github.com/Hivemapper/gnss-controller v1.0.3-0.20240819070221-78cf51b8a5c6/go.mod h1:womfs6qB93Ki7FczKxw0pR6H0MGNBM6j8bhCjVX4pWE=
 github.com/Hivemapper/sf-ublox v0.0.0-20240221201612-d92d22b86230 h1:gJnD/mOM6RzqRjkZ5HBA0VVDd7DhfgatO/mCCWl5Huw=
 github.com/Hivemapper/sf-ublox v0.0.0-20240221201612-d92d22b86230/go.mod h1:pfcwlN8XUYXVYAkPU2LrFZnXIS4EvpZaXh+qRKCN9Sg=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/Hivemapper/gnss-controller v1.0.3-0.20240514192901-01235228b063 h1:C56Dlm9qQ+SczRVg/hho/uqTK1nYaXyzQNkWPz/Ulbo=
+github.com/Hivemapper/gnss-controller v1.0.3-0.20240514192901-01235228b063/go.mod h1:womfs6qB93Ki7FczKxw0pR6H0MGNBM6j8bhCjVX4pWE=
 github.com/Hivemapper/sf-ublox v0.0.0-20240221201612-d92d22b86230 h1:gJnD/mOM6RzqRjkZ5HBA0VVDd7DhfgatO/mCCWl5Huw=
 github.com/Hivemapper/sf-ublox v0.0.0-20240221201612-d92d22b86230/go.mod h1:pfcwlN8XUYXVYAkPU2LrFZnXIS4EvpZaXh+qRKCN9Sg=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
@@ -137,6 +139,7 @@ golang.org/x/tools v0.19.0 h1:tfGCXNR1OsFG+sVdLAitlpjAvD/I6dHDKnYrpEZUHkw=
 golang.org/x/tools v0.19.0/go.mod h1:qoJWxmGSIBmAeriMx19ogtrEPrGtDbPK634QFIcLAhc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gonum.org/v1/gonum v0.0.0-20180816165407-929014505bf4/go.mod h1:Y+Yx5eoAFn32cQvJDxZx5Dpnq+c3wtXuadVZAcxbbBo=
 gonum.org/v1/gonum v0.0.0-20190606121551-14af50e936aa/go.mod h1:zXcK6UmEkbNk22MqyPrZPx3T6fsE/O56XzkDfeYUF+Y=
 gonum.org/v1/gonum v0.14.0 h1:2NiG67LD1tEH0D7kM+ps2V+fXmsAnpUeec7n8tcr4S0=


### PR DESCRIPTION
Ticket: https://linear.app/hivemapper/issue/IMCO-188/restore-datalogger-build-from-source-on-hdc

Point directly to the gnss-controller commit, instead of using a relative path

gnss-controller commit: https://github.com/Hivemapper/gnss-controller/pull/4/commits/78cf51b8a5c612019589e01c36c0b4edf2b75612

Related to: https://github.com/Hivemapper/hdc_firmware/pull/260