### PR TITLE
discard fsync false

### DIFF
--- a/data/imu/rawfeed.go
+++ b/data/imu/rawfeed.go
@@ -26,6 +26,18 @@ func (f *RawFeed) Run(axisMap *iim42652.AxisMap) error {
 
 	for {
 		time.Sleep(2 * time.Millisecond)
+
+		fsync, err := f.imu.GetFsync()
+		if err != nil {
+			return fmt.Errorf("getting fsync: %w", err)
+		}
+		fmt.Println("Fsync:", fsync)
+		// return early if fsync_int variable in is false
+		if !fsync.Fsync_int {
+			fmt.Println("Fsync_int is false")
+			continue
+		}
+
 		acceleration, err := f.imu.GetAcceleration()
 		if err != nil {
 			return fmt.Errorf("getting acceleration: %w", err)
@@ -40,12 +52,6 @@ func (f *RawFeed) Run(axisMap *iim42652.AxisMap) error {
 		if err != nil {
 			return fmt.Errorf("getting temperature: %w", err)
 		}
-
-		// fsync, err := f.imu.GetFsync()
-		// if err != nil {
-		// 	return fmt.Errorf("getting fsync: %w", err)
-		// }
-		// fmt.Println("fsync: ", fsync)
 
 		for _, handler := range f.handlers {
 			err := handler(

--- a/gnss-controller/device/neom9n/device.go
+++ b/gnss-controller/device/neom9n/device.go
@@ -124,10 +124,10 @@ func (n *Neom9n) Init(lastPosition *Position) error {
 	n.setConfig(0x20910635, []byte{0x01}, "CFG-MSGOUT-UBX_SEC_SIG_UART1")
 	n.setConfig(0x2091001b, []byte{0x01}, "CFG-MSGOUT-UBX_NAV_STATUS_UART1")
 	n.setConfig(0x2005000c, []byte{0x01}, "CFG-TP-TIMEGRID_TP1")
-	n.setConfig(0x40050002, uint32(50000), "CFG-TP-PERIOD_TP1")
-	n.setConfig(0x40050003, uint32(50000), "CFG-TP-PERIOD_LOCK_TP1")
-	n.setConfig(0x40050004, uint32(5000), "CFG-TP-LEN_TP1")
-	n.setConfig(0x40050005, uint32(5000), "CFG-TP-LEN_LOCK_TP1")
+	n.setConfig(0x40050002, uint32(5000), "CFG-TP-PERIOD_TP1")
+	n.setConfig(0x40050003, uint32(5000), "CFG-TP-PERIOD_LOCK_TP1")
+	n.setConfig(0x40050004, uint32(500), "CFG-TP-LEN_TP1")
+	n.setConfig(0x40050005, uint32(500), "CFG-TP-LEN_LOCK_TP1")
 	n.setConfig(0x20910346, []byte{0x01}, "CFG-MSGOUT-UBX_NAV_SIG_UART1")
 
 	if lastPosition != nil {

--- a/imu-controller/device/iim42652/fsync.go
+++ b/imu-controller/device/iim42652/fsync.go
@@ -6,20 +6,20 @@ import (
 
 type Fsync struct {
 	timedelta int16
-	fsync_int bool
+	Fsync_int bool
 }
 
 func NewFsync(timedelta int16, fsync_int bool) *Fsync {
 	fsync := &Fsync{
 		timedelta: timedelta,
-		fsync_int: fsync_int,
+		Fsync_int: fsync_int,
 	}
 
 	return fsync
 }
 
 func (f *Fsync) String() string {
-	return fmt.Sprintf("Fsync{FSYNC interrupt: %t, timedelta: %d}", f.fsync_int, f.timedelta)
+	return fmt.Sprintf("Fsync{FSYNC interrupt: %t, timedelta: %d}", f.Fsync_int, f.timedelta)
 }
 
 func (i *IIM42652) GetFsync() (*Fsync, error) {


### PR DESCRIPTION
Only log IMU data if FSYNC pulse from GNSS module has been received. The IMU is set to write at 200Hz, but we were previously reading data at 250-300 Hz (as fast as possible) and thus writing repeated values. This changes logs IMU values much closer to 200Hz as expected.

Before/after IMU frequency plots here: https://linear.app/hivemapper/issue/EDGE-449/slow-imu-logging