### PR TITLE
Update gnss rate to 10hz

### DIFF
--- a/data/imu/rawfeed.go
+++ b/data/imu/rawfeed.go
@@ -26,8 +26,6 @@ func (f *RawFeed) Run(axisMap *iim42652.AxisMap) error {
 	fmt.Println("Run imu raw feed")
 
 	for {
-		time.Sleep(2 * time.Millisecond)
-
 		fsync, err := f.imu.GetFsync()
 		if err != nil {
 			return fmt.Errorf("[ERROR] error getting fsync: %w", err)

--- a/gnss-controller/device/neom9n/device.go
+++ b/gnss-controller/device/neom9n/device.go
@@ -112,7 +112,7 @@ func (n *Neom9n) Init(lastPosition *Position) error {
 	n.setConfig(546374149, value, "CFG-MSGOUT-UBX_RXM_MEASX_UART1")
 	n.setConfig(0x2091034b, []byte{0x01}, "CFG-MSGOUT-UBX_SEC_ECSIGN_UART1")
 
-	n.setConfig(807469057, uint16(128), "CFG-RATE-MEAS 0x30210001") // CFG-RATE-MEAS 0x30210001 U2 0.001 s Nominal time between GNSS measurements
+	n.setConfig(807469057, uint16(100), "CFG-RATE-MEAS 0x30210001") // CFG-RATE-MEAS 0x30210001 U2 0.001 s Nominal time between GNSS measurements
 	n.setConfig(807469058, uint16(1), "CFG-RATE-NAV")               // CFG-RATE-NAV 0x30210002 Ratio of number of measurements to number of navigation solutions
 
 	n.setConfig(0x20910084, []byte{0x01}, "CFG-MSGOUT-UBX_NAV_COV_UART1")

--- a/imu-controller/device/iim42652/acceleration.go
+++ b/imu-controller/device/iim42652/acceleration.go
@@ -41,7 +41,7 @@ func NewAcceleration(x, y, z int16, sensitivity AccelerationSensitivity) *Accele
 }
 
 func (a *Acceleration) String() string {
-	return fmt.Sprintf("Acceleration{camX:%.5f, camY:%.5f, camZ: %.5f, totalMagn: %.5f}", a.Z, a.X, a.Y, a.TotalMagnitude)
+	return fmt.Sprintf("Acceleration{camX:%.5f, camY:%.5f, camZ: %.5f, totalMagn: %.5f}", a.X, a.Y, a.Z, a.TotalMagnitude)
 }
 
 func (a *Acceleration) CamX() float64 {


### PR DESCRIPTION
Updated GNSS solution frequency to 10 Hz (every 100ms). Not detrimental effects noted during drive tests.

Position solution frequency stable at 10Hz.

![image](https://github.com/user-attachments/assets/9665dc4e-4ea5-4e42-be5e-c290d695d2cd)
