### PR TITLE
Add IMU FSYNC logging

### DIFF
--- a/cmd/datalogger/log.go
+++ b/cmd/datalogger/log.go
@@ -61,7 +61,7 @@ func init() {
 
 	// Redis
 	LogCmd.Flags().Bool("enable-redis-logs", false, "enable redis logging")
-	LogCmd.Flags().Int("max-redis-imu-entries", 1000, "max imu entries in redis")
+	LogCmd.Flags().Int("max-redis-imu-entries", 5000, "max imu entries in redis")
 	LogCmd.Flags().Int("max-redis-mag-entries", 1000, "max mag entries in redis")
 	LogCmd.Flags().Int("max-redis-gnss-entries", 1000, "max gnss entries in redis")
 	LogCmd.Flags().Int("max-redis-gnss-auth-entries", 1000, "max gnss auth entries in redis")

--- a/data/imu/rawfeed.go
+++ b/data/imu/rawfeed.go
@@ -79,7 +79,7 @@ func (f *RawFeed) Run(axisMap *iim42652.AxisMap) error {
 		for _, fifoData := range fifopackets {
 			if !fifoData.Fsync.FsyncInt && betweenFsyncs >= 200 {
 				// Discard excess samples (usually only 1)
-				// fmt.Println("More than 200 samples between fsyncs")
+				fmt.Println(time.Now().UTC(), "More than 200 samples between fsyncs")
 				continue
 			}
 			validPackets = append(validPackets, fifoData)
@@ -89,7 +89,6 @@ func (f *RawFeed) Run(axisMap *iim42652.AxisMap) error {
 					f.fsync_error_counter++
 					if f.fsync_error_counter >= 60 {
 						fmt.Println(time.Now().UTC(), "[Warning] ", betweenFsyncs, "samples since last fsync, repeated every 60 instances")
-						fmt.Println(time.Now().UTC(), "fifoChan queue size:", len(fifoChan))
 						f.fsync_error_counter = 0
 					}
 				}
@@ -129,13 +128,18 @@ func (f *RawFeed) Run(axisMap *iim42652.AxisMap) error {
 				// Sent successfully
 			default:
 				// Channel full, drop or log
-				fmt.Println(time.Now().UTC(), "Warning: fifo data channel full, dropping FIFO data")
+				fmt.Println(
+					time.Now().UTC(),
+					"Warning: fifo data channel full, dropping FIFO data. Current queue size:",
+					len(fifoChan),
+					"capacity:", cap(fifoChan),
+				)
 			}
 		}
 
 		prev_last_packet_time = time_of_last_packet
 
-		time.Sleep(25 * time.Millisecond)
+		time.Sleep(100 * time.Millisecond)
 
 	}
 }

--- a/data/imu/rawfeed.go
+++ b/data/imu/rawfeed.go
@@ -89,6 +89,7 @@ func (f *RawFeed) Run(axisMap *iim42652.AxisMap) error {
 					f.fsync_error_counter++
 					if f.fsync_error_counter >= 60 {
 						fmt.Println(time.Now().UTC(), "[Warning] ", betweenFsyncs, "samples since last fsync, repeated every 60 instances")
+						fmt.Println(time.Now().UTC(), "fifoChan queue size:", len(fifoChan))
 						f.fsync_error_counter = 0
 					}
 				}
@@ -134,7 +135,7 @@ func (f *RawFeed) Run(axisMap *iim42652.AxisMap) error {
 
 		prev_last_packet_time = time_of_last_packet
 
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(25 * time.Millisecond)
 
 	}
 }

--- a/data/imu/rawfeed.go
+++ b/data/imu/rawfeed.go
@@ -9,9 +9,8 @@ import (
 )
 
 type RawFeed struct {
-	imu                 *iim42652.IIM42652
-	handlers            []RawFeedHandler
-	fsync_error_counter int
+	imu      *iim42652.IIM42652
+	handlers []RawFeedHandler
 }
 
 type ImuRawData struct {
@@ -23,9 +22,8 @@ type ImuRawData struct {
 
 func NewRawFeed(imu *iim42652.IIM42652, handlers ...RawFeedHandler) *RawFeed {
 	return &RawFeed{
-		imu:                 imu,
-		handlers:            handlers,
-		fsync_error_counter: 58,
+		imu:      imu,
+		handlers: handlers,
 	}
 }
 
@@ -55,9 +53,12 @@ func (f *RawFeed) Run(axisMap *iim42652.AxisMap) error {
 	}()
 
 	var betweenFsyncs int = -1
+	var betweenFsyncsFull int = -1
 	var prev_last_packet_time time.Time
 	var time_of_last_packet time.Time
 	var packet_time time.Time
+	var high_freq_counter int = 58
+	var low_freq_counter int = 58
 
 	for {
 
@@ -70,6 +71,7 @@ func (f *RawFeed) Run(axisMap *iim42652.AxisMap) error {
 		if betweenFsyncs == -1 {
 			// ignore first set of data
 			betweenFsyncs = 1
+			betweenFsyncsFull = 1
 			prev_last_packet_time = time_of_last_packet
 
 			continue
@@ -78,23 +80,32 @@ func (f *RawFeed) Run(axisMap *iim42652.AxisMap) error {
 		validPackets := make([]iim42652.FifoImuRawData, 0, len(fifopackets))
 		for _, fifoData := range fifopackets {
 			if !fifoData.Fsync.FsyncInt && betweenFsyncs >= 200 {
+				betweenFsyncsFull++
 				// Discard excess samples (usually only 1)
-				fmt.Println(time.Now().UTC(), "More than 200 samples between fsyncs")
 				continue
 			}
 			validPackets = append(validPackets, fifoData)
 
 			if fifoData.Fsync.FsyncInt {
 				if betweenFsyncs < 200 {
-					f.fsync_error_counter++
-					if f.fsync_error_counter >= 60 {
-						fmt.Println(time.Now().UTC(), "[Warning] ", betweenFsyncs, "samples since last fsync, repeated every 60 instances")
-						f.fsync_error_counter = 0
+					low_freq_counter++
+					if low_freq_counter >= 60 {
+						fmt.Println(time.Now().UTC(), "[Warning] ", betweenFsyncs, " samples since last fsync, repeated every 60 instances")
+						low_freq_counter = 0
+					}
+				}
+				if betweenFsyncsFull > 200 {
+					high_freq_counter++
+					if high_freq_counter >= 60 {
+						fmt.Println(time.Now().UTC(), "[Warning] ", betweenFsyncsFull, " samples between fsyncs, repeated every 60 instances")
+						high_freq_counter = 0
 					}
 				}
 				betweenFsyncs = 1
+				betweenFsyncsFull = 1
 			} else {
 				betweenFsyncs++
+				betweenFsyncsFull++
 			}
 		}
 

--- a/logger/redis.go
+++ b/logger/redis.go
@@ -132,12 +132,11 @@ func (s *Redis) LogImuData(imudata ImuRedisWrapper) error {
 		return err
 	}
 
-	// Push the JSON data to the Redis list
-	if err := s.DB.LPush(s.ctx, "ImuData", protodata).Err(); err != nil {
-		return err
-	}
-
-	if err := s.DB.LTrim(s.ctx, "ImuData", 0, int64(s.maxImuEntries)).Err(); err != nil {
+	pipe := s.DB.Pipeline()
+	pipe.LPush(s.ctx, "ImuData", protodata)
+	pipe.LTrim(s.ctx, "ImuData", 0, int64(s.maxImuEntries))
+	_, err = pipe.Exec(s.ctx)
+	if err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
- adds logging for low frequency fsync samples: https://linear.app/hivemapper/issue/EDGE-1016/investigate-fsync-not-aligning-for-users
- increase default IMU redis max entries to 5000 
- pipe send and trip imuData in one go rather than two commands (supposedly faster)