### PR TITLE
CAP-142 Add ability to generate and play back gnss data

### DIFF
--- a/cmd/datalogger/datahandler.go
+++ b/cmd/datalogger/datahandler.go
@@ -25,12 +25,13 @@ func NewDataHandler(
 	maxRedisGnssEntries int,
 	maxRedisGnssAuthEntries int,
 	redisLogProtoText bool,
+	redisWriteGnssToFile string,
 ) (*DataHandler, error) {
 
 	var redisLogger *logger.Redis = nil
 	var err error
 	if redisLogsEnabled {
-		redisLogger = logger.NewRedis(maxRedisImuEntries, maxRedisMagEntries, maxRedisGnssEntries, maxRedisGnssAuthEntries, redisLogProtoText)
+		redisLogger = logger.NewRedis(maxRedisImuEntries, maxRedisMagEntries, maxRedisGnssEntries, maxRedisGnssAuthEntries, redisLogProtoText, redisWriteGnssToFile)
 		err := redisLogger.Init()
 		if err != nil {
 			return nil, fmt.Errorf("initializing redis logger database: %w", err)
@@ -120,4 +121,8 @@ func (h *DataHandler) HandleRawImuFeed(acceleration *imu.Acceleration, angularRa
 		}
 	}
 	return nil
+}
+
+func (h *DataHandler) HandleGnssReplayData(redisKey string, data []byte) error {
+	return h.redisLogger.LogGnssReplayData(redisKey, data)
 }

--- a/cmd/datalogger/log.go
+++ b/cmd/datalogger/log.go
@@ -76,11 +76,11 @@ func logRun(cmd *cobra.Command, _ []string) error {
 	redisLogPbtxt := getBoolOrDefault(cmd, "redis-log-pbtxt")
 
 	if (redisWriteGnssToFile != "" || redisReadGnssFromFile != "") && !enableRedisLogs {
-		panic("enable-redis-logs must be set if either gnss-file flag is set")
+		return fmt.Errorf("enable-redis-logs must be set if either gnss-file flag is set")
 	}
 
 	if redisWriteGnssToFile != "" && !redisLogPbtxt {
-		panic("redis-log-pbtxt must be set if redis-write-gnss-to-file is set")
+		return fmt.Errorf("redis-log-pbtxt must be set if redis-write-gnss-to-file is set")
 	}
 
 	axisMap, err := parseAxisMap(mustGetString(cmd, "imu-axis-map"))

--- a/cmd/datalogger/log.go
+++ b/cmd/datalogger/log.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -11,8 +10,6 @@ import (
 	"github.com/Hivemapper/hivemapper-data-logger/data/gnss"
 	"github.com/Hivemapper/hivemapper-data-logger/data/imu"
 	"github.com/Hivemapper/hivemapper-data-logger/data/magnetometer"
-	"github.com/gorilla/handlers"
-	gmux "github.com/gorilla/mux"
 	"github.com/spf13/cobra"
 	"github.com/streamingfast/imu-controller/device/iim42652"
 )
@@ -66,6 +63,8 @@ func init() {
 	LogCmd.Flags().Int("max-redis-gnss-entries", 1000, "max gnss entries in redis")
 	LogCmd.Flags().Int("max-redis-gnss-auth-entries", 1000, "max gnss auth entries in redis")
 	LogCmd.Flags().Bool("redis-log-pbtxt", false, "enable logging sensor data into redis in pbtxt format")
+	LogCmd.Flags().String("redis-write-gnss-to-file", "", "write protobuf to file instead of redis")
+	LogCmd.Flags().String("redis-read-gnss-from-file", "", "read protobuf from file instead of sensors")
 
 	RootCmd.AddCommand(LogCmd)
 }
@@ -104,9 +103,6 @@ func logRun(cmd *cobra.Command, _ []string) error {
 	conf := imu.LoadConfig(mustGetString(cmd, "imu-config-file"))
 	fmt.Println("Config: ", conf.String())
 
-	serialConfigName := mustGetString(cmd, "gnss-dev-path")
-	mgaOfflineFilePath := mustGetString(cmd, "gnss-mga-offline-file-path")
-
 	dataHandler, err := NewDataHandler(
 		getBoolOrDefault(cmd, "enable-redis-logs"),
 		getIntOrDefault(cmd, "max-redis-imu-entries"),
@@ -114,16 +110,46 @@ func logRun(cmd *cobra.Command, _ []string) error {
 		getIntOrDefault(cmd, "max-redis-gnss-entries"),
 		getIntOrDefault(cmd, "max-redis-gnss-auth-entries"),
 		getBoolOrDefault(cmd, "redis-log-pbtxt"),
+		mustGetString(cmd, "redis-write-gnss-to-file"),
 	)
 	if err != nil {
 		return fmt.Errorf("creating data handler: %w", err)
 	}
 
-	gnssDevice := neom9n.NewNeom9n(serialConfigName, mgaOfflineFilePath, mustGetInt(cmd, "gnss-initial-baud-rate"), mustGetBool(cmd, "gnss-measx-enabled"))
-	err = gnssDevice.Init(nil)
+	err = initializeSensorThreads(
+		imuDevice,
+		dataHandler,
+		axisMap,
+		mustGetString(cmd, "gnss-dev-path"),
+		mustGetString(cmd, "gnss-mga-offline-file-path"),
+		mustGetInt(cmd, "gnss-initial-baud-rate"),
+		mustGetBool(cmd, "gnss-measx-enabled"),
+		mustGetBool(cmd, "enable-magnetometer"),
+		mustGetBool(cmd, "skip-filtering"),
+		mustGetString(cmd, "redis-read-gnss-from-file"),
+	)
 	if err != nil {
-		return fmt.Errorf("initializing neom9n: %w", err)
+		return err
 	}
+
+	for {
+		time.Sleep(10 * time.Second)
+	}
+}
+
+func initializeSensorThreads(
+	imuDevice *iim42652.IIM42652,
+	dataHandler *DataHandler,
+	axisMap *iim42652.AxisMap,
+	gnssDevPath string,
+	mgaOfflineFilePath string,
+	gnssInitBaudRate int,
+	gnssMeasxEnabled bool,
+	enableMagnetometer bool,
+	skipFiltering bool,
+	gnssReadFile string,
+) error {
+	var err error
 
 	rawImuEventFeed := imu.NewRawFeed(
 		imuDevice,
@@ -136,26 +162,46 @@ func logRun(cmd *cobra.Command, _ []string) error {
 		}
 	}()
 
-	var options []gnss.Option
-	if mustGetBool(cmd, "skip-filtering") {
-		options = append(options, gnss.WithSkipFiltering())
-	}
-	gnssEventFeed := gnss.NewGnssFeed(
-		[]gnss.GnssDataHandler{
-			dataHandler.HandlerGnssData,
-		},
-		nil,
-		options...,
-	)
-
-	go func() {
-		err = gnssEventFeed.Run(gnssDevice, dataHandler.redisLogger, dataHandler.redisLogsEnabled)
+	if gnssReadFile == "" {
+		gnssDevice := neom9n.NewNeom9n(gnssDevPath, mgaOfflineFilePath, gnssInitBaudRate, gnssMeasxEnabled)
+		err = gnssDevice.Init(nil)
 		if err != nil {
-			panic(fmt.Errorf("running gnss event feed: %w", err))
+			return fmt.Errorf("initializing neom9n: %w", err)
 		}
-	}()
 
-	if mustGetBool(cmd, "enable-magnetometer") {
+		var options []gnss.Option
+		if skipFiltering {
+			options = append(options, gnss.WithSkipFiltering())
+		}
+		gnssEventFeed := gnss.NewGnssFeed(
+			[]gnss.GnssDataHandler{
+				dataHandler.HandlerGnssData,
+			},
+			nil,
+			options...,
+		)
+
+		go func() {
+			err = gnssEventFeed.Run(gnssDevice, dataHandler.redisLogger, dataHandler.redisLogsEnabled)
+			if err != nil {
+				panic(fmt.Errorf("running gnss event feed: %w", err))
+			}
+		}()
+	} else {
+		gnssReplayFeed := gnss.NewGnssReplayFeed(
+			gnssReadFile,
+			dataHandler.HandleGnssReplayData,
+		)
+
+		go func() {
+			err = gnssReplayFeed.Run()
+			if err != nil {
+				panic(fmt.Errorf("running gnss event feed: %w", err))
+			}
+		}()
+	}
+
+	if enableMagnetometer {
 		magnetometerEventFeed := magnetometer.NewRawFeed(
 			dataHandler.HandlerMagnetometerData,
 		)
@@ -171,20 +217,6 @@ func logRun(cmd *cobra.Command, _ []string) error {
 			}
 		}()
 	}
-
-	httpListenAddr := mustGetString(cmd, "http-listen-addr")
-
-	origins := handlers.AllowedOrigins([]string{"*"})
-	headers := handlers.AllowedHeaders([]string{"Content-Type"})
-	methods := handlers.AllowedMethods([]string{"GET", "POST", "PUT", "DELETE", "OPTIONS"})
-	router := gmux.NewRouter().StrictSlash(true)
-
-	err = http.ListenAndServe(httpListenAddr, handlers.CORS(origins, headers, methods)(router))
-	fmt.Printf("Starting http server on %s ...\n", httpListenAddr)
-	if err != nil {
-		return fmt.Errorf("running http server: %w", err)
-	}
-
 	return nil
 }
 

--- a/cmd/datalogger/log.go
+++ b/cmd/datalogger/log.go
@@ -70,6 +70,19 @@ func init() {
 }
 
 func logRun(cmd *cobra.Command, _ []string) error {
+	redisWriteGnssToFile := mustGetString(cmd, "redis-write-gnss-to-file")
+	redisReadGnssFromFile := mustGetString(cmd, "redis-read-gnss-from-file")
+	enableRedisLogs := getBoolOrDefault(cmd, "enable-redis-logs")
+	redisLogPbtxt := getBoolOrDefault(cmd, "redis-log-pbtxt")
+
+	if (redisWriteGnssToFile != "" || redisReadGnssFromFile != "") && !enableRedisLogs {
+		panic("enable-redis-logs must be set if either gnss-file flag is set")
+	}
+
+	if redisWriteGnssToFile != "" && !redisLogPbtxt {
+		panic("redis-log-pbtxt must be set if redis-write-gnss-to-file is set")
+	}
+
 	axisMap, err := parseAxisMap(mustGetString(cmd, "imu-axis-map"))
 	if err != nil {
 		return fmt.Errorf("parsing axis map: %w", err)
@@ -104,13 +117,13 @@ func logRun(cmd *cobra.Command, _ []string) error {
 	fmt.Println("Config: ", conf.String())
 
 	dataHandler, err := NewDataHandler(
-		getBoolOrDefault(cmd, "enable-redis-logs"),
+		enableRedisLogs,
 		getIntOrDefault(cmd, "max-redis-imu-entries"),
 		getIntOrDefault(cmd, "max-redis-mag-entries"),
 		getIntOrDefault(cmd, "max-redis-gnss-entries"),
 		getIntOrDefault(cmd, "max-redis-gnss-auth-entries"),
-		getBoolOrDefault(cmd, "redis-log-pbtxt"),
-		mustGetString(cmd, "redis-write-gnss-to-file"),
+		redisLogPbtxt,
+		redisWriteGnssToFile,
 	)
 	if err != nil {
 		return fmt.Errorf("creating data handler: %w", err)
@@ -126,7 +139,7 @@ func logRun(cmd *cobra.Command, _ []string) error {
 		mustGetBool(cmd, "gnss-measx-enabled"),
 		mustGetBool(cmd, "enable-magnetometer"),
 		mustGetBool(cmd, "skip-filtering"),
-		mustGetString(cmd, "redis-read-gnss-from-file"),
+		redisReadGnssFromFile,
 	)
 	if err != nil {
 		return err

--- a/data/gnss/replay.go
+++ b/data/gnss/replay.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Hivemapper/hivemapper-data-logger/logger"
 	sensordata "github.com/Hivemapper/hivemapper-data-logger/proto-out"
+	"golang.org/x/sys/unix"
 	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/proto"
 )
@@ -21,10 +22,19 @@ type GnssReplayFeed struct {
 	dataHandler    GnssReplayDataHandler
 }
 
-func NewGnssReplayFeed(replayFilePath string, datahandler GnssReplayDataHandler) *GnssReplayFeed {
+func monotonicTime() float64 {
+	var ts unix.Timespec
+	err := unix.ClockGettime(unix.CLOCK_MONOTONIC, &ts)
+	if err != nil {
+		panic(err)
+	}
+	return float64(ts.Sec)*1000. + float64(ts.Nsec)/1e6
+}
+
+func NewGnssReplayFeed(replayFilePath string, dataHandler GnssReplayDataHandler) *GnssReplayFeed {
 	g := &GnssReplayFeed{
-		replayFilePath,
-		datahandler,
+		replayFilePath: replayFilePath,
+		dataHandler:    dataHandler,
 	}
 	return g
 }
@@ -56,7 +66,6 @@ func (f *GnssReplayFeed) Run() error {
 
 	firstEpoch := true
 
-	// read each line of the file
 	for {
 		line, err := reader.ReadString('\n')
 		if err != nil {
@@ -67,7 +76,6 @@ func (f *GnssReplayFeed) Run() error {
 			return fmt.Errorf("error reading from gnss replay file: %s", err)
 		}
 
-		// json with "rediskey" and "data" (pbtxt) entries
 		var entry logger.GnssReplayEvent
 		err = json.Unmarshal([]byte(line), &entry)
 		if err != nil {
@@ -96,7 +104,14 @@ func (f *GnssReplayFeed) Run() error {
 			continue
 		}
 
-		// now serialize to bytes
+		// Monotonic time and system time in the replayed data needs to be updated
+		// so that it will be accepted by bee-sensor-fusion.
+		if navPvt, ok := msg.(*sensordata.NavPvt); ok {
+			navPvt.UptimeMs = monotonicTime()
+			navPvt.SystemTime = time.Now().UTC().Format("2006-01-02 15:04:05.000000")
+			fmt.Printf("[DEBUG] Set NavPvt.SystemTime to: %s\n", navPvt.SystemTime)
+		}
+
 		binary_data, err := proto.Marshal(msg)
 		if err != nil {
 			fmt.Printf("error marshalling gnss data: %s\n", err)

--- a/data/gnss/replay.go
+++ b/data/gnss/replay.go
@@ -21,8 +21,6 @@ type GnssReplayFeed struct {
 	dataHandler    GnssReplayDataHandler
 }
 
-
-
 func NewGnssReplayFeed(replayFilePath string, dataHandler GnssReplayDataHandler) *GnssReplayFeed {
 	g := &GnssReplayFeed{
 		replayFilePath: replayFilePath,
@@ -108,6 +106,8 @@ func (f *GnssReplayFeed) Run() error {
 			continue
 		}
 
-		f.dataHandler(entry.RedisKey, binary_data)
+		if err := f.dataHandler(entry.RedisKey, binary_data); err != nil {
+			fmt.Printf("error pushing gnss replay data to redis: %s\n", err)
+		}
 	}
 }

--- a/data/gnss/replay.go
+++ b/data/gnss/replay.go
@@ -82,7 +82,6 @@ func (f *GnssReplayFeed) Run() error {
 			fmt.Printf("error unmarshalling gnss json line: %s\n", err)
 			continue
 		}
-		fmt.Printf("%s\n", entry.RedisKey)
 
 		if entry.RedisKey == "RxmRawx" {
 			if !firstEpoch {
@@ -109,7 +108,6 @@ func (f *GnssReplayFeed) Run() error {
 		if navPvt, ok := msg.(*sensordata.NavPvt); ok {
 			navPvt.UptimeMs = monotonicTime()
 			navPvt.SystemTime = time.Now().UTC().Format("2006-01-02 15:04:05.000000")
-			fmt.Printf("[DEBUG] Set NavPvt.SystemTime to: %s\n", navPvt.SystemTime)
 		}
 
 		binary_data, err := proto.Marshal(msg)

--- a/data/gnss/replay.go
+++ b/data/gnss/replay.go
@@ -1,0 +1,108 @@
+package gnss
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/Hivemapper/hivemapper-data-logger/logger"
+	sensordata "github.com/Hivemapper/hivemapper-data-logger/proto-out"
+	"google.golang.org/protobuf/encoding/prototext"
+	"google.golang.org/protobuf/proto"
+)
+
+type GnssReplayDataHandler func(redisKey string, data []byte) error
+
+type GnssReplayFeed struct {
+	replayFilePath string
+	dataHandler    GnssReplayDataHandler
+}
+
+func NewGnssReplayFeed(replayFilePath string, datahandler GnssReplayDataHandler) *GnssReplayFeed {
+	g := &GnssReplayFeed{
+		replayFilePath,
+		datahandler,
+	}
+	return g
+}
+
+// map rediskey to protobuf type
+var redisKeyToProto = map[string]proto.Message{
+	"NavStatus":  &sensordata.NavStatus{},
+	"NavDop":     &sensordata.NavDop{},
+	"MonRf":      &sensordata.MonRf{},
+	"RxmMeasx":   &sensordata.RxmMeasx{},
+	"RxmRawx":    &sensordata.RxmRawx{},
+	"RxmSfrbx":   &sensordata.RxmSfrbx{},
+	"TimTp":      &sensordata.TimTp{},
+	"NavCov":     &sensordata.NavCov{},
+	"NavPvt":     &sensordata.NavPvt{},
+	"NavPosecef": &sensordata.NavPosecef{},
+	"NavVelecef": &sensordata.NavVelecef{},
+	"NavSig":     &sensordata.NavSig{},
+	"NavTimegps": &sensordata.NavTimegps{},
+}
+
+func (f *GnssReplayFeed) Run() error {
+	replayFileHandle, err := os.Open(f.replayFilePath)
+	if err != nil {
+		return fmt.Errorf("opening gnss replay file: %w", err)
+	}
+	defer replayFileHandle.Close()
+	reader := bufio.NewReader(replayFileHandle)
+
+	firstEpoch := true
+
+	// read each line of the file
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			if err == io.EOF {
+				fmt.Println("done reading gnss replay file")
+				return nil
+			}
+			return fmt.Errorf("error reading from gnss replay file: %s", err)
+		}
+
+		// json with "rediskey" and "data" (pbtxt) entries
+		var entry logger.GnssReplayEvent
+		err = json.Unmarshal([]byte(line), &entry)
+		if err != nil {
+			fmt.Printf("error unmarshalling gnss json line: %s\n", err)
+			continue
+		}
+		fmt.Printf("%s\n", entry.RedisKey)
+
+		if entry.RedisKey == "RxmRawx" {
+			if !firstEpoch {
+				time.Sleep(250 * time.Millisecond)
+			}
+			firstEpoch = false
+		}
+
+		protoType, ok := redisKeyToProto[entry.RedisKey]
+		if !ok {
+			fmt.Printf("unknown redis key: %s\n", entry.RedisKey)
+			continue
+		}
+
+		msg := protoType
+		err = prototext.Unmarshal([]byte(entry.Data), msg)
+		if err != nil {
+			fmt.Printf("error unmarshalling gnss data pbtxt: %s\n", err)
+			continue
+		}
+
+		// now serialize to bytes
+		binary_data, err := proto.Marshal(msg)
+		if err != nil {
+			fmt.Printf("error marshalling gnss data: %s\n", err)
+			continue
+		}
+
+		f.dataHandler(entry.RedisKey, binary_data)
+	}
+}

--- a/data/gnss/replay.go
+++ b/data/gnss/replay.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/Hivemapper/hivemapper-data-logger/logger"
 	sensordata "github.com/Hivemapper/hivemapper-data-logger/proto-out"
-	"golang.org/x/sys/unix"
 	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/proto"
 )
@@ -22,14 +21,7 @@ type GnssReplayFeed struct {
 	dataHandler    GnssReplayDataHandler
 }
 
-func monotonicTime() float64 {
-	var ts unix.Timespec
-	err := unix.ClockGettime(unix.CLOCK_MONOTONIC, &ts)
-	if err != nil {
-		panic(err)
-	}
-	return float64(ts.Sec)*1000. + float64(ts.Nsec)/1e6
-}
+
 
 func NewGnssReplayFeed(replayFilePath string, dataHandler GnssReplayDataHandler) *GnssReplayFeed {
 	g := &GnssReplayFeed{
@@ -106,7 +98,7 @@ func (f *GnssReplayFeed) Run() error {
 		// Monotonic time and system time in the replayed data needs to be updated
 		// so that it will be accepted by bee-sensor-fusion.
 		if navPvt, ok := msg.(*sensordata.NavPvt); ok {
-			navPvt.UptimeMs = monotonicTime()
+			navPvt.UptimeMs = logger.MonotonicTime()
 			navPvt.SystemTime = time.Now().UTC().Format("2006-01-02 15:04:05.000000")
 		}
 

--- a/generate_replay.py
+++ b/generate_replay.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+import json
+import math
+import sys
+import argparse
+from datetime import datetime, timedelta, timezone
+
+# WGS-84 constants
+WGS84_A = 6378137.0         # semi-major axis in meters
+WGS84_E2 = 0.00669437999014 # first eccentricity squared
+
+def latlon_to_ecef(lat_deg, lon_deg, alt_m):
+    lat_rad = math.radians(lat_deg)
+    lon_rad = math.radians(lon_deg)
+    
+    sin_lat = math.sin(lat_rad)
+    cos_lat = math.cos(lat_rad)
+    sin_lon = math.sin(lon_rad)
+    cos_lon = math.cos(lon_rad)
+    
+    N = WGS84_A / math.sqrt(1.0 - WGS84_E2 * sin_lat * sin_lat)
+    
+    x = (N + alt_m) * cos_lat * cos_lon
+    y = (N + alt_m) * cos_lat * sin_lon
+    z = (N * (1.0 - WGS84_E2) + alt_m) * sin_lat
+    
+    return x, y, z
+
+def ned_to_ecef_vel(lat_deg, lon_deg, vel_n, vel_e, vel_d):
+    lat_rad = math.radians(lat_deg)
+    lon_rad = math.radians(lon_deg)
+    
+    sin_lat = math.sin(lat_rad)
+    cos_lat = math.cos(lat_rad)
+    sin_lon = math.sin(lon_rad)
+    cos_lon = math.cos(lon_rad)
+    
+    # NED to ECEF rotation matrix
+    vx = -sin_lat * cos_lon * vel_n - sin_lon * vel_e - cos_lat * cos_lon * vel_d
+    vy = -sin_lat * sin_lon * vel_n + cos_lon * vel_e - cos_lat * sin_lon * vel_d
+    vz = cos_lat * vel_n - sin_lat * vel_d
+    
+    return vx, vy, vz
+
+def generate_simulation(duration_sec, output_path, speed_kmh, start_lat, start_lon, heading_deg):
+    # Calculate speed in meters/second
+    speed_mps = speed_kmh / 3.6
+    
+    # Epoch rate: 4Hz (every 250ms)
+    dt = 0.25
+    steps = int(duration_sec / dt)
+    
+    # Start time
+    now = datetime.now(timezone.utc)
+    # Start GPS Time of Week (TOW) - let's pick a default
+    start_itow_ms = 517405500
+    start_uptime_ms = 25326299.0
+    
+    lat = start_lat
+    lon = start_lon
+    alt_m = 30.0  # Constant altitude (30 meters in SF)
+    
+    heading_rad = math.radians(heading_deg)
+    
+    with open(output_path, 'w') as f:
+        for step in range(steps):
+            t_offset = step * dt
+            step_time = now + timedelta(seconds=t_offset)
+            itow_ms = start_itow_ms + int(t_offset * 1000)
+            uptime_ms = start_uptime_ms + (t_offset * 1000)
+            
+            # 1. Update position (Dead reckoning)
+            ds = speed_mps * dt  # distance traveled in this step
+            lat_rad = math.radians(lat)
+            
+            new_lat_rad = lat_rad + (ds * math.cos(heading_rad) / WGS84_A)
+            new_lon_rad = math.radians(lon) + (ds * math.sin(heading_rad) / (WGS84_A * math.cos(lat_rad)))
+            
+            lat = math.degrees(new_lat_rad)
+            lon = math.degrees(new_lon_rad)
+            
+            # Convert to ECEF (centimeters)
+            x_m, y_m, z_m = latlon_to_ecef(lat, lon, alt_m)
+            ecef_x_cm = int(x_m * 100)
+            ecef_y_cm = int(y_m * 100)
+            ecef_z_cm = int(z_m * 100)
+            
+            # Calculate velocities
+            vel_n_m_s = speed_mps * math.cos(heading_rad)
+            vel_e_m_s = speed_mps * math.sin(heading_rad)
+            vel_d_m_s = 0.0
+            
+            g_speed_mm_s = int(round(speed_mps * 1000))
+            vel_n_mm_s = int(round(vel_n_m_s * 1000))
+            vel_e_mm_s = int(round(vel_e_m_s * 1000))
+            vel_d_mm_s = int(round(vel_d_m_s * 1000))
+            
+            # Convert NED velocity to ECEF velocity
+            ecef_vx_m_s, ecef_vy_m_s, ecef_vz_m_s = ned_to_ecef_vel(lat, lon, vel_n_m_s, vel_e_m_s, vel_d_m_s)
+            ecef_vx_cm_s = int(round(ecef_vx_m_s * 100))
+            ecef_vy_cm_s = int(round(ecef_vy_m_s * 100))
+            ecef_vz_cm_s = int(round(ecef_vz_m_s * 100))
+            
+            head_mot_dege5 = int(round(heading_deg * 100000))
+            head_veh_dege5 = int(round(heading_deg * 100000))
+            
+            lon_dege7 = int(lon * 1e7)
+            lat_dege7 = int(lat * 1e7)
+            
+            # Format times
+            sys_time_str = step_time.strftime('%Y-%m-%d %H:%M:%S') + f'.{step_time.microsecond * 1000:09d} +0000 UTC'
+            rcv_tow_s = (itow_ms / 1000.0) + 0.004
+            
+            year = step_time.year
+            month = step_time.month
+            day = step_time.day
+            hour = step_time.hour
+            minute = step_time.minute
+            second = step_time.second
+            nano = (step_time.microsecond * 1000)
+            
+            # Write the epoch messages (sequence of 9 messages)
+            
+            # 1. RxmRawx
+            rxm_rawx_data = (
+                f'system_time:"{sys_time_str}" rcv_tow_s:{rcv_tow_s:.3f} week:2422 leap_s:18 num_meas:2 rec_stat:1 version:1 '
+                f'meas:{{pr_mes:2.3631966949941665e+07 cp_mes:1.2418683236464132e+08 do_mes:-2038.1473388671875 sv_id:32 locktime_ms:8000 cno_dbhz:25 pr_stdev_m_1e2_2n:8 cp_stdev_cycles_4e3:10 do_stdev_hz_2e3_2n:8 trk_stat:7}} '
+                f'meas:{{pr_mes:2.3793212786808778e+07 cp_mes:1.2503417617119361e+08 do_mes:339.675048828125 sv_id:2 cno_dbhz:23 pr_stdev_m_1e2_2n:10 cp_stdev_cycles_4e3:15 do_stdev_hz_2e3_2n:12 trk_stat:1}}'
+            )
+            f.write(json.dumps({"redisKey": "RxmRawx", "data": rxm_rawx_data}) + '\n')
+            
+            # 2. NavPvt
+            nav_pvt_data = (
+                f'system_time:"{sys_time_str}" itow_ms:{itow_ms} uptime_ms:{uptime_ms:.7e} '
+                f'year_y:{year} month_month:{month} day_d:{day} hour_h:{hour} min_min:{minute} sec_s:{second} '
+                f'valid:55 t_acc_ns:96186120 nano_ns:{nano} fix_type:3 flags:1 flags2:164 num_sv:10 lon_dege7:{lon_dege7} lat_dege7:{lat_dege7} '
+                f'height_mm:{int(alt_m * 1000)} hmsl_mm:{int(alt_m * 1000)} h_acc_mm:2500 v_acc_mm:3800 '
+                f'vel_n_mm_s:{vel_n_mm_s} vel_e_mm_s:{vel_e_mm_s} vel_d_mm_s:{vel_d_mm_s} g_speed_mm_s:{g_speed_mm_s} '
+                f'head_mot_dege5:{head_mot_dege5} s_acc_mm_s:20008 head_acc_dege5:18000000 pdop:150 '
+                f'head_veh_dege5:{head_veh_dege5}'
+            )
+            f.write(json.dumps({"redisKey": "NavPvt", "data": nav_pvt_data}) + '\n')
+            
+            # 3. NavPosecef
+            nav_posecef_data = f'itow_ms:{itow_ms} ecef_x_cm:{ecef_x_cm} ecef_y_cm:{ecef_y_cm} ecef_z_cm:{ecef_z_cm} p_acc_cm:655312640'
+            f.write(json.dumps({"redisKey": "NavPosecef", "data": nav_posecef_data}) + '\n')
+            
+            # 4. NavVelecef
+            nav_velecef_data = f'itow_ms:{itow_ms} ecef_vx_cm_s:{ecef_vx_cm_s} ecef_vy_cm_s:{ecef_vy_cm_s} ecef_vz_cm_s:{ecef_vz_cm_s} s_acc_cm_s:2001'
+            f.write(json.dumps({"redisKey": "NavVelecef", "data": nav_velecef_data}) + '\n')
+            
+            # 5. NavSig
+            nav_sig_data = (
+                f'system_time:"{sys_time_str}" itow_ms:{itow_ms} num_sigs:6 '
+                f'sigs:{{sv_id:2 cno_dbhz:23 quality_ind:4 sig_flags:1}} '
+                f'sigs:{{sv_id:2 sig_id:7 cno_dbhz:10 quality_ind:4 sig_flags:1}} '
+                f'sigs:{{sv_id:6 cno_dbhz:24 quality_ind:3 sig_flags:1}} '
+                f'sigs:{{sv_id:8 quality_ind:1 sig_flags:1}} '
+                f'sigs:{{sv_id:32 cno_dbhz:25 quality_ind:7 sig_flags:1}} '
+                f'sigs:{{sv_id:32 sig_id:7 quality_ind:1 sig_flags:1}}'
+            )
+            f.write(json.dumps({"redisKey": "NavSig", "data": nav_sig_data}) + '\n')
+            
+            # 6. NavStatus
+            nav_status_data = f'itow_ms:{itow_ms} flags:76 flags2:8 msss:25336384'
+            f.write(json.dumps({"redisKey": "NavStatus", "data": nav_status_data}) + '\n')
+            
+            # 7. NavDop
+            nav_dop_data = (
+                f'system_time:"{sys_time_str}" itow_ms:{itow_ms} gdop:180 pdop:150 tdop:100 vdop:120 hdop:90 ndop:80 edop:50'
+            )
+            f.write(json.dumps({"redisKey": "NavDop", "data": nav_dop_data}) + '\n')
+            
+            # 8. NavTimegps
+            nav_timegps_data = f'itow_ms:{itow_ms} week:2422 leap_s:18 valid:7 t_acc_ns:96186096'
+            f.write(json.dumps({"redisKey": "NavTimegps", "data": nav_timegps_data}) + '\n')
+            
+            # 9. NavCov
+            nav_cov_data = (
+                f'itow_ms:{itow_ms} pos_cov_valid:1 vel_cov_valid:1 '
+                f'pos_cov_n_n:1.4314547183616e+13 pos_cov_n_e:-524288 pos_cov_n_d:4.718592e+06 '
+                f'pos_cov_e_e:1.4314541940736e+13 pos_cov_e_d:-2.8573696e+07 pos_cov_d_d:1.4314380460032e+13 '
+                f'vel_cov_n_n:400.31231689453125 vel_cov_n_e:0.0013885498046875 vel_cov_n_d:0.008087158203125 '
+                f'vel_cov_e_e:400.3036193847656 vel_cov_e_d:-0.0516510009765625 vel_cov_d_d:400.0122375488281'
+            )
+            f.write(json.dumps({"redisKey": "NavCov", "data": nav_cov_data}) + '\n')
+            
+            # Output MonRf occasionally (every 10 seconds / 40 steps)
+            if step % 40 == 0:
+                mon_rf_data = (
+                    f'system_time:"{sys_time_str}" n_block:2 '
+                    f'rf_blocks:{{ant_status:1 ant_power:2 noise_per_ms:85 agc_cnt:1488 jam_ind:97 ofs_i:17 mag_i:255 ofs_q:13 mag_q:255}} '
+                    f'rf_blocks:{{block_id:1 ant_status:1 ant_power:2 noise_per_ms:48 agc_cnt:2418 jam_ind:97 ofs_i:21 mag_i:255 ofs_q:21 mag_q:255}}'
+                )
+                f.write(json.dumps({"redisKey": "MonRf", "data": mon_rf_data}) + '\n')
+
+    print(f"Simulation file successfully generated at: {output_path}")
+    print(f"Duration: {duration_sec} seconds")
+    print(f"Path traveled from: ({start_lat}, {start_lon}) to ({lat:.6f}, {lon:.6f})")
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Generate a simulated GNSS pbtxt/JSON replay log file.")
+    parser.add_argument('--duration', type=float, default=60.0, help="Duration of simulation in seconds")
+    parser.add_argument('--output', type=str, default="gnss_sim.txt", help="Output file path")
+    parser.add_argument('--speed', type=float, default=50.0, help="Speed of the car in km/h")
+    parser.add_argument('--lat', type=float, default=37.7749, help="Starting Latitude (default: SF)")
+    parser.add_argument('--lon', type=float, default=-122.4194, help="Starting Longitude (default: SF)")
+    parser.add_argument('--heading', type=float, default=90.0, help="Heading direction in degrees (0=North, 90=East, etc.)")
+    
+    args = parser.parse_args()
+    generate_simulation(args.duration, args.output, args.speed, args.lat, args.lon, args.heading)

--- a/logger/redis.go
+++ b/logger/redis.go
@@ -222,7 +222,7 @@ func (s *Redis) Marshal(message proto.Message) ([]byte, error) {
 	return data, err
 }
 
-func monotonicTime() float64 {
+func MonotonicTime() float64 {
 	var ts unix.Timespec
 	err := unix.ClockGettime(unix.CLOCK_MONOTONIC, &ts)
 	if err != nil {
@@ -233,7 +233,7 @@ func monotonicTime() float64 {
 
 func (s *Redis) HandleUbxMessage(msg interface{}) error {
 	systemTime := time.Now().UTC()
-	upTime := monotonicTime()
+	upTime := MonotonicTime()
 
 	var protodata []byte = nil
 	var err error

--- a/logger/redis.go
+++ b/logger/redis.go
@@ -2,7 +2,9 @@ package logger
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/Hivemapper/gnss-controller/device/neom9n"
@@ -74,19 +76,32 @@ type Redis struct {
 	maxGnssEntries     int
 	maxGnssAuthEntries int
 	logProtoText       bool
+	gnssFilePath       string
+	gnssFileHandle     *os.File
 }
 
-func NewRedis(maxImuEntries int, maxMagEntries int, maxGnssEntries int, maxGnssAuthEntries int, logProtoText bool) *Redis {
+func NewRedis(maxImuEntries int, maxMagEntries int, maxGnssEntries int, maxGnssAuthEntries int, logProtoText bool, gnssFilePath string) *Redis {
 	return &Redis{
 		maxImuEntries:      maxImuEntries,
 		maxMagEntries:      maxMagEntries,
 		maxGnssEntries:     maxGnssEntries,
 		maxGnssAuthEntries: maxGnssAuthEntries,
 		logProtoText:       logProtoText,
+		gnssFilePath:       gnssFilePath,
 	}
 }
 
 func (s *Redis) Init() error {
+	if len(s.gnssFilePath) != 0 {
+		fmt.Printf("Opening file %s for logging\n", s.gnssFilePath)
+		var err error
+		s.gnssFileHandle, err = os.Create(s.gnssFilePath)
+		if err != nil {
+			return fmt.Errorf("opening file: %w", err)
+		}
+		fmt.Printf("Redis logger initialized (writing to file)")
+	}
+
 	fmt.Println("Initializing Redis logger")
 	s.DB = redis.NewClient(&redis.Options{
 		Addr: "localhost:6379", // Use your Redis server address
@@ -570,8 +585,42 @@ func (s *Redis) HandleUbxMessage(msg interface{}) error {
 		return err
 	}
 
+	if s.gnssFileHandle == nil {
+		// Push the proto data to the Redis list
+		if err := s.DB.LPush(s.ctx, redisKey, protodata).Err(); err != nil {
+			return err
+		}
+
+		// Trim the list to the max number of entries
+		if err := s.DB.LTrim(s.ctx, redisKey, 0, int64(s.maxGnssEntries)).Err(); err != nil {
+			return err
+		}
+	} else {
+		// This should only be used with pbtxt
+
+		// serialize into json with two fields "redisKey" and "data"
+		entry := GnssReplayEvent{
+			RedisKey: redisKey,
+			Data:     string(protodata),
+		}
+
+		jsonData, err := json.Marshal(entry)
+		if err != nil {
+			return fmt.Errorf("failed to marshal gnss data to json: %w", err)
+		}
+
+		_, err = s.gnssFileHandle.Write(append(jsonData, '\n'))
+		if err != nil {
+			return fmt.Errorf("failed to write gnss data to file: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (s *Redis) LogGnssReplayData(redisKey string, data []byte) error {
 	// Push the proto data to the Redis list
-	if err := s.DB.LPush(s.ctx, redisKey, protodata).Err(); err != nil {
+	if err := s.DB.LPush(s.ctx, redisKey, data).Err(); err != nil {
 		return err
 	}
 
@@ -581,4 +630,9 @@ func (s *Redis) HandleUbxMessage(msg interface{}) error {
 	}
 
 	return nil
+}
+
+type GnssReplayEvent struct {
+	RedisKey string `json:"redisKey"`
+	Data     string `json:"data"`
 }


### PR DESCRIPTION
Ticket: https://linear.app/hivemapper/issue/CAP-142/more-sophisticated-e2e-tests-for-map-ai

- option to record gnss data from the current session and write it to a file
- option to read gnss data from a previous session and send to redis
- python helper script that generates fake gnss data of a car moving in San Francisco

Locally this seems to produce framerequests. Unfortunately I'm running into map-ai issues with my camera so could not verify selections were occuring.

To kick off gnss replay

```
/opt/dashcam/bin/datalogger log --gnss-mga-offline-file-path /data/mgaoffline.ubx --db-log-ttl=30m --gnss-dev-path=/dev/ttyS2 --imu-dev-path=/dev/spidev0.0 --imu-axis-map=CamX:Y,CamY:X,CamZ:Z --imu-inverted X:true,Y:false,Z:false --enable-magnetometer --enable-redis-logs --redis-write-gnss-to-file "" --redis-read-gnss-from-file "/data/gnss.txt
```

to signal a start for bee-sensor-fusion (only needed if map-ai is not running

`redis-cli LPUSH MapAiStarted 0`

verify that frameRequests are sent: either tail the sensor fusion logs or

`redis-cli LRANGE FrameRequest 0 -1`